### PR TITLE
fix: make help desk/feedback URLs link to catsky repo instead

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,8 +11,7 @@ export const BSKY_SERVICE = 'https://bsky.social'
 export const BSKY_SERVICE_DID = 'did:web:bsky.social'
 export const PUBLIC_BSKY_SERVICE = 'https://public.api.bsky.app'
 export const DEFAULT_SERVICE = BSKY_SERVICE
-const HELP_DESK_LANG = 'en-us'
-export const HELP_DESK_URL = `https://blueskyweb.zendesk.com/hc/${HELP_DESK_LANG}`
+export const HELP_DESK_URL = `https://github.com/NekoDrone/catsky-social/issues/new/choose`
 export const EMBED_SERVICE = 'https://embed.bsky.app'
 export const EMBED_SCRIPT = `${EMBED_SERVICE}/static/embed.js`
 export const BSKY_DOWNLOAD_URL = 'https://bsky.app/download'
@@ -38,22 +37,12 @@ export const DISCOVER_DEBUG_DIDS: Record<string, true> = {
   'did:plc:2dzyut5lxna5ljiaasgeuffz': true, // darrin.bsky.team
 }
 
-const BASE_FEEDBACK_FORM_URL = `${HELP_DESK_URL}/requests/new`
-export function FEEDBACK_FORM_URL({
-  email,
-  handle,
-}: {
+const BASE_FEEDBACK_FORM_URL = `${HELP_DESK_URL}`
+export function FEEDBACK_FORM_URL(_params: {
   email?: string
   handle?: string
 }): string {
-  let str = BASE_FEEDBACK_FORM_URL
-  if (email) {
-    str += `?tf_anonymous_requester_email=${encodeURIComponent(email)}`
-    if (handle) {
-      str += `&tf_17205412673421=${encodeURIComponent(handle)}`
-    }
-  }
-  return str
+  return BASE_FEEDBACK_FORM_URL
 }
 
 export const MAX_DISPLAY_NAME = 64


### PR DESCRIPTION
Similar to the patch from deer social but for catsky instead

meow meow :3

Also may want to update the `DISCOVER_DEBUG_DIDS` constant below this to be better and furrier but that's a later issue to solve(if one you even want to solve)