### PR TITLE
fix: android crash on notifications tab from whitespace

### DIFF
--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -747,7 +747,7 @@ function ExpandListPressable({
       </Pressable>
     )
   } else {
-    return <>{children} </>
+    return <>{children}</>
   }
 }
 


### PR DESCRIPTION
removed unwrapped whitespace in `NotificationFeedItem.tsx:750` that caused "Text strings must be rendered within a <Text> component" error, as reported in #59 