### PR TITLE
feat: buttons to open external mastodon post + open in pdsls

### DIFF
--- a/src/components/PostControls/ShareMenu/ShareMenuItems.tsx
+++ b/src/components/PostControls/ShareMenu/ShareMenuItems.tsx
@@ -5,6 +5,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 
+import {useOpenLink} from '#/lib/hooks/useOpenLink'
 import {makeProfileLink} from '#/lib/routes/links'
 import {type NavigationProp} from '#/lib/routes/types'
 import {shareText, shareUrl} from '#/lib/sharing'
@@ -13,6 +14,7 @@ import {logger} from '#/logger'
 import {isIOS} from '#/platform/detection'
 import {useAgeAssurance} from '#/state/ageAssurance/useAgeAssurance'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
+import {useShowExternalShareButtons} from '#/state/preferences/external-share-buttons'
 import {useSession} from '#/state/session'
 import * as Toast from '#/view/com/util/Toast'
 import {atoms as a} from '#/alf'
@@ -23,6 +25,7 @@ import {ArrowOutOfBoxModified_Stroke2_Corner2_Rounded as ArrowOutOfBoxIcon} from
 import {ChainLink_Stroke2_Corner0_Rounded as ChainLinkIcon} from '#/components/icons/ChainLink'
 import {Clipboard_Stroke2_Corner2_Rounded as ClipboardIcon} from '#/components/icons/Clipboard'
 import {PaperPlane_Stroke2_Corner0_Rounded as PaperPlaneIcon} from '#/components/icons/PaperPlane'
+import {SquareArrowTopRight_Stroke2_Corner0_Rounded as ExternalIcon} from '#/components/icons/SquareArrowTopRight'
 import * as Menu from '#/components/Menu'
 import {useDevMode} from '#/storage/hooks/dev-mode'
 import {RecentChats} from './RecentChats'
@@ -38,6 +41,7 @@ let ShareMenuItems = ({
   const sendViaChatControl = useDialogControl()
   const [devModeEnabled] = useDevMode()
   const {isAgeRestricted} = useAgeAssurance()
+  const openLink = useOpenLink()
 
   const postUri = post.uri
   const postAuthor = useProfileShadow(post.author)
@@ -88,6 +92,18 @@ let ShareMenuItems = ({
     shareText(postAuthor.did)
   }
 
+  const showExternalShareButtons = useShowExternalShareButtons()
+  const isBridgyPost = !!post.record.bridgyOriginalUrl
+  const bridgyOriginalUrl = post.record.bridgyOriginalUrl as string | undefined
+
+  const onOpenOriginalPost = () => {
+    bridgyOriginalUrl && openLink(bridgyOriginalUrl, true)
+  }
+
+  const onOpenPostInPdsls = () => {
+    openLink(`https://pdsls.dev/${post.uri}`, true)
+  }
+
   return (
     <>
       <Menu.Outer>
@@ -107,6 +123,32 @@ let ShareMenuItems = ({
                 <Trans>Send via direct message</Trans>
               </Menu.ItemText>
               <Menu.ItemIcon icon={PaperPlaneIcon} position="right" />
+            </Menu.Item>
+          </Menu.Group>
+        )}
+
+        {showExternalShareButtons && (
+          <Menu.Group>
+            {isBridgyPost && (
+              <Menu.Item
+                testID="postDropdownOpenOriginalPost"
+                label={_(msg`Open original post`)}
+                onPress={onOpenOriginalPost}>
+                <Menu.ItemText>
+                  <Trans>Open original post</Trans>
+                </Menu.ItemText>
+                <Menu.ItemIcon icon={ExternalIcon} position="right" />
+              </Menu.Item>
+            )}
+
+            <Menu.Item
+              testID="postDropdownOpenInPdsls"
+              label={_(msg`Open post in pdsls`)}
+              onPress={onOpenPostInPdsls}>
+              <Menu.ItemText>
+                <Trans>Open post in pdsls</Trans>
+              </Menu.ItemText>
+              <Menu.ItemIcon icon={ExternalIcon} position="right" />
             </Menu.Item>
           </Menu.Group>
         )}

--- a/src/components/PostControls/ShareMenu/ShareMenuItems.tsx
+++ b/src/components/PostControls/ShareMenu/ShareMenuItems.tsx
@@ -93,11 +93,13 @@ let ShareMenuItems = ({
   }
 
   const showExternalShareButtons = useShowExternalShareButtons()
-  const isBridgyPost = !!post.record.bridgyOriginalUrl
-  const bridgyOriginalUrl = post.record.bridgyOriginalUrl as string | undefined
+  const isBridgedPost =
+    !!post.record.bridgyOriginalUrl || !!post.record.fediverseId
+  const originalPostUrl = (post.record.bridgyOriginalUrl ||
+    post.record.fediverseId) as string | undefined
 
   const onOpenOriginalPost = () => {
-    bridgyOriginalUrl && openLink(bridgyOriginalUrl, true)
+    originalPostUrl && openLink(originalPostUrl, true)
   }
 
   const onOpenPostInPdsls = () => {
@@ -129,7 +131,7 @@ let ShareMenuItems = ({
 
         {showExternalShareButtons && (
           <Menu.Group>
-            {isBridgyPost && (
+            {isBridgedPost && (
               <Menu.Item
                 testID="postDropdownOpenOriginalPost"
                 label={_(msg`Open original post`)}

--- a/src/components/PostControls/ShareMenu/ShareMenuItems.tsx
+++ b/src/components/PostControls/ShareMenu/ShareMenuItems.tsx
@@ -145,10 +145,10 @@ let ShareMenuItems = ({
 
             <Menu.Item
               testID="postDropdownOpenInPdsls"
-              label={_(msg`Open post in pdsls`)}
+              label={_(msg`Open post in PDSls`)}
               onPress={onOpenPostInPdsls}>
               <Menu.ItemText>
-                <Trans>Open post in pdsls</Trans>
+                <Trans>Open post in PDSls</Trans>
               </Menu.ItemText>
               <Menu.ItemIcon icon={ExternalIcon} position="right" />
             </Menu.Item>

--- a/src/components/PostControls/ShareMenu/ShareMenuItems.web.tsx
+++ b/src/components/PostControls/ShareMenu/ShareMenuItems.web.tsx
@@ -4,6 +4,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 
+import {useOpenLink} from '#/lib/hooks/useOpenLink'
 import {makeProfileLink} from '#/lib/routes/links'
 import {type NavigationProp} from '#/lib/routes/types'
 import {shareText, shareUrl} from '#/lib/sharing'
@@ -12,6 +13,7 @@ import {logger} from '#/logger'
 import {isWeb} from '#/platform/detection'
 import {useAgeAssurance} from '#/state/ageAssurance/useAgeAssurance'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
+import {useShowExternalShareButtons} from '#/state/preferences/external-share-buttons'
 import {useSession} from '#/state/session'
 import {useBreakpoints} from '#/alf'
 import {useDialogControl} from '#/components/Dialog'
@@ -21,6 +23,7 @@ import {ChainLink_Stroke2_Corner0_Rounded as ChainLinkIcon} from '#/components/i
 import {Clipboard_Stroke2_Corner2_Rounded as ClipboardIcon} from '#/components/icons/Clipboard'
 import {CodeBrackets_Stroke2_Corner0_Rounded as CodeBracketsIcon} from '#/components/icons/CodeBrackets'
 import {PaperPlane_Stroke2_Corner0_Rounded as Send} from '#/components/icons/PaperPlane'
+import {SquareArrowTopRight_Stroke2_Corner0_Rounded as ExternalIcon} from '#/components/icons/SquareArrowTopRight'
 import * as Menu from '#/components/Menu'
 import {useDevMode} from '#/storage/hooks/dev-mode'
 import {type ShareMenuItemsProps} from './ShareMenuItems.types'
@@ -39,6 +42,7 @@ let ShareMenuItems = ({
   const sendViaChatControl = useDialogControl()
   const [devModeEnabled] = useDevMode()
   const {isAgeRestricted} = useAgeAssurance()
+  const openLink = useOpenLink()
 
   const postUri = post.uri
   const postCid = post.cid
@@ -80,6 +84,18 @@ let ShareMenuItems = ({
     shareText(postAuthor.did)
   }
 
+  const showExternalShareButtons = useShowExternalShareButtons()
+  const isBridgyPost = !!record.bridgyOriginalUrl
+  const bridgyOriginalUrl = record.bridgyOriginalUrl as string | undefined
+
+  const onOpenOriginalPost = () => {
+    bridgyOriginalUrl && openLink(bridgyOriginalUrl, true)
+  }
+
+  const onOpenPostInPdsls = () => {
+    openLink(`https://pdsls.dev/${post.uri}`, true)
+  }
+
   const copyLinkItem = (
     <Menu.Item
       testID="postDropdownShareBtn"
@@ -96,6 +112,30 @@ let ShareMenuItems = ({
     <>
       <Menu.Outer>
         {!hideInPWI && copyLinkItem}
+
+        {showExternalShareButtons && isBridgyPost && (
+          <Menu.Item
+            testID="postDropdownOpenOriginalPost"
+            label={_(msg`Open original post`)}
+            onPress={onOpenOriginalPost}>
+            <Menu.ItemText>
+              <Trans>Open original post</Trans>
+            </Menu.ItemText>
+            <Menu.ItemIcon icon={ExternalIcon} position="right" />
+          </Menu.Item>
+        )}
+
+        {showExternalShareButtons && (
+          <Menu.Item
+            testID="postDropdownOpenInPdsls"
+            label={_(msg`Open post in pdsls`)}
+            onPress={onOpenPostInPdsls}>
+            <Menu.ItemText>
+              <Trans>Open post in pdsls</Trans>
+            </Menu.ItemText>
+            <Menu.ItemIcon icon={ExternalIcon} position="right" />
+          </Menu.Item>
+        )}
 
         {hasSession && !isAgeRestricted && (
           <Menu.Item

--- a/src/components/PostControls/ShareMenu/ShareMenuItems.web.tsx
+++ b/src/components/PostControls/ShareMenu/ShareMenuItems.web.tsx
@@ -85,11 +85,13 @@ let ShareMenuItems = ({
   }
 
   const showExternalShareButtons = useShowExternalShareButtons()
-  const isBridgyPost = !!record.bridgyOriginalUrl
-  const bridgyOriginalUrl = record.bridgyOriginalUrl as string | undefined
+  const isBridgedPost =
+    !!post.record.bridgyOriginalUrl || !!post.record.fediverseId
+  const originalPostUrl = (post.record.bridgyOriginalUrl ||
+    post.record.fediverseId) as string | undefined
 
   const onOpenOriginalPost = () => {
-    bridgyOriginalUrl && openLink(bridgyOriginalUrl, true)
+    originalPostUrl && openLink(originalPostUrl, true)
   }
 
   const onOpenPostInPdsls = () => {
@@ -113,7 +115,7 @@ let ShareMenuItems = ({
       <Menu.Outer>
         {!hideInPWI && copyLinkItem}
 
-        {showExternalShareButtons && isBridgyPost && (
+        {showExternalShareButtons && isBridgedPost && (
           <Menu.Item
             testID="postDropdownOpenOriginalPost"
             label={_(msg`Open original post`)}

--- a/src/components/PostControls/ShareMenu/ShareMenuItems.web.tsx
+++ b/src/components/PostControls/ShareMenu/ShareMenuItems.web.tsx
@@ -130,10 +130,10 @@ let ShareMenuItems = ({
         {showExternalShareButtons && (
           <Menu.Item
             testID="postDropdownOpenInPdsls"
-            label={_(msg`Open post in pdsls`)}
+            label={_(msg`Open post in PDSls`)}
             onPress={onOpenPostInPdsls}>
             <Menu.ItemText>
-              <Trans>Open post in pdsls</Trans>
+              <Trans>Open post in PDSls</Trans>
             </Menu.ItemText>
             <Menu.ItemIcon icon={ExternalIcon} position="right" />
           </Menu.Item>

--- a/src/screens/Settings/ExperimentalSettings.tsx
+++ b/src/screens/Settings/ExperimentalSettings.tsx
@@ -19,11 +19,16 @@ import {
   useDirectFetchRecords,
   useSetDirectFetchRecords,
 } from '#/state/preferences/direct-fetch-records'
+import {
+  useSetShowExternalShareButtons,
+  useShowExternalShareButtons,
+} from '#/state/preferences/external-share-buttons'
 import * as SettingsList from '#/screens/Settings/components/SettingsList'
 import {atoms as a} from '#/alf'
 import {Admonition} from '#/components/Admonition'
 import * as Toggle from '#/components/forms/Toggle'
 import {Atom_Stroke2_Corner0_Rounded as ExperimentalIcon} from '#/components/icons/Atom'
+import {ChainLink_Stroke2_Corner0_Rounded as ChainLinkIcon} from '#/components/icons/ChainLink'
 import {Eye_Stroke2_Corner0_Rounded as VisibilityIcon} from '#/components/icons/Eye'
 import {PaintRoller_Stroke2_Corner2_Rounded as PaintRollerIcon} from '#/components/icons/PaintRoller'
 import * as Layout from '#/components/Layout'
@@ -41,6 +46,9 @@ export function ExperimentalSettingsScreen({}: Props) {
 
   const directFetchRecords = useDirectFetchRecords()
   const setDirectFetchRecords = useSetDirectFetchRecords()
+
+  const showExternalShareButtons = useShowExternalShareButtons()
+  const setShowExternalShareButtons = useSetShowExternalShareButtons()
 
   const [gates, setGatesView] = useState(Object.fromEntries(useGatesCache()))
   const dangerousSetGate = useDangerousSetGate()
@@ -116,6 +124,28 @@ export function ExperimentalSettingsScreen({}: Props) {
               <Toggle.LabelText style={[a.flex_1]}>
                 <Trans>
                   TODO: Fall back to constellation api to find blocked replies
+                </Trans>
+              </Toggle.LabelText>
+              <Toggle.Platform />
+            </Toggle.Item>
+          </SettingsList.Group>
+
+          <SettingsList.Group contentContainerStyle={[a.gap_sm]}>
+            <SettingsList.ItemIcon icon={ChainLinkIcon} />
+            <SettingsList.ItemText>
+              <Trans>Bridging and Fediverse</Trans>
+            </SettingsList.ItemText>
+            <Toggle.Item
+              name="external_share_buttons"
+              label={_(
+                msg`Show "Open original post" and "Open post in pdsls" buttons`,
+              )}
+              value={showExternalShareButtons}
+              onChange={value => setShowExternalShareButtons(value)}
+              style={[a.w_full]}>
+              <Toggle.LabelText style={[a.flex_1]}>
+                <Trans>
+                  Show "Open original post" and "Open post in pdsls" buttons
                 </Trans>
               </Toggle.LabelText>
               <Toggle.Platform />

--- a/src/screens/Settings/ExperimentalSettings.tsx
+++ b/src/screens/Settings/ExperimentalSettings.tsx
@@ -138,14 +138,14 @@ export function ExperimentalSettingsScreen({}: Props) {
             <Toggle.Item
               name="external_share_buttons"
               label={_(
-                msg`Show "Open original post" and "Open post in pdsls" buttons`,
+                msg`Show "Open original post" and "Open post in PDSls" buttons`,
               )}
               value={showExternalShareButtons}
               onChange={value => setShowExternalShareButtons(value)}
               style={[a.w_full]}>
               <Toggle.LabelText style={[a.flex_1]}>
                 <Trans>
-                  Show "Open original post" and "Open post in pdsls" buttons
+                  Show "Open original post" and "Open post in PDSls" buttons
                 </Trans>
               </Toggle.LabelText>
               <Toggle.Platform />

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -130,6 +130,8 @@ const schema = z.object({
   directFetchRecords: z.boolean().optional(),
   unfollowConfirm: z.boolean().optional(),
 
+  showExternalShareButtons: z.boolean().optional(),
+
   /** @deprecated */
   mutedThreads: z.array(z.string()),
   trendingDisabled: z.boolean().optional(),
@@ -187,6 +189,7 @@ export const defaults: Schema = {
   constellationEnabled: false,
   directFetchRecords: false,
   unfollowConfirm: false,
+  showExternalShareButtons: false,
 }
 
 export function tryParse(rawData: string): Schema | undefined {

--- a/src/state/preferences/external-share-buttons.tsx
+++ b/src/state/preferences/external-share-buttons.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+type StateContext = persisted.Schema['showExternalShareButtons']
+type SetContext = (v: persisted.Schema['showExternalShareButtons']) => void
+
+const stateContext = React.createContext<StateContext>(
+  persisted.defaults.showExternalShareButtons,
+)
+const setContext = React.createContext<SetContext>(
+  (_: persisted.Schema['showExternalShareButtons']) => {},
+)
+
+export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [state, setState] = React.useState(
+    persisted.get('showExternalShareButtons'),
+  )
+
+  const setStateWrapped = React.useCallback(
+    (
+      showExternalShareButtons: persisted.Schema['showExternalShareButtons'],
+    ) => {
+      setState(showExternalShareButtons)
+      persisted.write('showExternalShareButtons', showExternalShareButtons)
+    },
+    [setState],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate(
+      'showExternalShareButtons',
+      nextShowExternalShareButtons => {
+        setState(nextShowExternalShareButtons)
+      },
+    )
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={setStateWrapped}>
+        {children}
+      </setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export function useShowExternalShareButtons() {
+  return React.useContext(stateContext)
+}
+
+export function useSetShowExternalShareButtons() {
+  return React.useContext(setContext)
+}

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -6,6 +6,7 @@ import {Provider as ConstellationProvider} from './constellation-enabled'
 import {Provider as DirectFetchRecordsProvider} from './direct-fetch-records'
 import {Provider as DisableHapticsProvider} from './disable-haptics'
 import {Provider as ExternalEmbedsProvider} from './external-embeds-prefs'
+import {Provider as ExternalShareButtonsProvider} from './external-share-buttons'
 import {Provider as GoLinksProvider} from './go-links-enabled'
 import {Provider as HiddenPostsProvider} from './hidden-posts'
 import {Provider as InAppBrowserProvider} from './in-app-browser'
@@ -36,31 +37,33 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   return (
     <LanguagesProvider>
       <AltTextRequiredProvider>
-        <GoLinksProvider>
-          <DirectFetchRecordsProvider>
-            <ConstellationProvider>
-              <LargeAltBadgeProvider>
-                <ExternalEmbedsProvider>
-                  <HiddenPostsProvider>
-                    <InAppBrowserProvider>
-                      <DisableHapticsProvider>
-                        <AutoplayProvider>
-                          <UsedStarterPacksProvider>
-                            <SubtitlesProvider>
-                              <TrendingSettingsProvider>
-                                <KawaiiProvider>{children}</KawaiiProvider>
-                              </TrendingSettingsProvider>
-                            </SubtitlesProvider>
-                          </UsedStarterPacksProvider>
-                        </AutoplayProvider>
-                      </DisableHapticsProvider>
-                    </InAppBrowserProvider>
-                  </HiddenPostsProvider>
-                </ExternalEmbedsProvider>
-              </LargeAltBadgeProvider>
-            </ConstellationProvider>
-          </DirectFetchRecordsProvider>
-        </GoLinksProvider>
+        <ExternalShareButtonsProvider>
+          <GoLinksProvider>
+            <DirectFetchRecordsProvider>
+              <ConstellationProvider>
+                <LargeAltBadgeProvider>
+                  <ExternalEmbedsProvider>
+                    <HiddenPostsProvider>
+                      <InAppBrowserProvider>
+                        <DisableHapticsProvider>
+                          <AutoplayProvider>
+                            <UsedStarterPacksProvider>
+                              <SubtitlesProvider>
+                                <TrendingSettingsProvider>
+                                  <KawaiiProvider>{children}</KawaiiProvider>
+                                </TrendingSettingsProvider>
+                              </SubtitlesProvider>
+                            </UsedStarterPacksProvider>
+                          </AutoplayProvider>
+                        </DisableHapticsProvider>
+                      </InAppBrowserProvider>
+                    </HiddenPostsProvider>
+                  </ExternalEmbedsProvider>
+                </LargeAltBadgeProvider>
+              </ConstellationProvider>
+            </DirectFetchRecordsProvider>
+          </GoLinksProvider>
+        </ExternalShareButtonsProvider>
       </AltTextRequiredProvider>
     </LanguagesProvider>
   )


### PR DESCRIPTION
Adds antler's "open original link" and "open in pdsls" buttons to the share menu. 

<img width="695" height="820" alt="screenshot-12_23-53-28" src="https://github.com/user-attachments/assets/a4f784e8-d81e-44a7-995f-32ba2ca66941" />

I've tested and they both work, including wafrn and bridgy posts for fediverse and a bunch of random posts for pdsls.